### PR TITLE
Change default albedo to reflect more acccurate lake water conditions

### DIFF
--- a/inst/extdata/gotm.yaml
+++ b/inst/extdata/gotm.yaml
@@ -122,8 +122,8 @@ surface:
       file:                             # path to file with time series [default=]
       column: 1                         # index of column to read from [default=1]
    albedo:
-      method: 1                         # method to compute albedo [0=constant, 1=Payne (1972), 2=Cogley (1979); default=1]
-      constant_value: 0.0               # constant value to use throughout the simulation [fraction; min=0.0; max=1.0; default=0.0]
+      method: 0                         # method to compute albedo [0=constant, 1=Payne (1972), 2=Cogley (1979); default=1]
+      constant_value: 0.08              # constant value to use throughout the simulation [fraction; min=0.0; max=1.0; default=0.0]
    ice:
       model: 0                          # model [0=none, 1=Lebedev (1938), 2=MyLake, 3=Winton; default=0]
       H: 0.0                            # initial ice thickness [m; default=0.0]


### PR DESCRIPTION
The default albedo has very high estimations of albedo [0.3-0.6]. Adjusted so it takes a constant value [0.08], and this also allows for it to be a parameter to be included in calibration routines.

![image](https://github.com/aemon-j/GOTMr/assets/23136262/98dbd1b3-e833-4b15-944e-147714f37c4d)
Albedo output from GOTM using the default method (1; Payne (1972) method).
